### PR TITLE
refactor: remove redundant event_name input from workflow call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
       test: "run python -m unittest discover"
       build_branch: "build"
       build_main: "build"
-      event_name: ${{ github.event_name }}
       artifact_path: "dist"
       publish_github_release: "true"
       publish_python_libraries: "false"


### PR DESCRIPTION
## Summary
Removes redundant \`event_name: \${{ github.event_name }}\` input from the reusable workflow call.

\`github.event_name\` (and \`github.ref_name\`) are available directly in all reusable workflows — they don't need to be passed as inputs. Depends on tehw0lf/workflows#28.