### PR TITLE
fix(ci): add pull-requests: write permission to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       packages: write
       security-events: write
+      pull-requests: write
     with:
       tool: "uv"
       install: "sync --all-extras --dev --group lint"


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` permission to the reusable workflow call

## Reason
All repos using reusable workflows from `tehw0lf/workflows` require `pull-requests: write` to function correctly, regardless of the build tool used.